### PR TITLE
feat: アプリケーションのバージョン表示機能を追加

### DIFF
--- a/src/components/ConfigManager.tsx
+++ b/src/components/ConfigManager.tsx
@@ -2,7 +2,8 @@
 import React, { useState, useEffect, forwardRef, useImperativeHandle, useRef, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-shell';
-import { TauriCommands, AppConfig, AwsCredentials, AwsConfig, AppState, SystemStatus, RestoreInfo, RestoreNotification, LifecyclePolicyStatus, LifecycleRule, S3Object, RestoreStatusResult, ConfigValidationResult, AwsAuthResult, PermissionCheck } from '../services/tauriCommands';
+import { getVersion } from '@tauri-apps/api/app';
+import { TauriCommands, AppConfig, AwsCredentials, AwsConfig, AppState, SystemStatus, RestoreInfo, RestoreNotification, LifecyclePolicyStatus, LifecycleRule, S3Object, RestoreStatusResult, ConfigValidationResult, AwsAuthResult, PermissionCheck, UploadItem } from '../services/tauriCommands';
 import { AWS_REGIONS, DEFAULT_REGION } from '../constants/aws-regions';
 // RestoreManagerは直接統合済み
 import { UploadManager } from './UploadManager';
@@ -41,6 +42,7 @@ export const ConfigManager = forwardRef<ConfigManagerRef, ConfigManagerProps>(({
 }, ref) => {
   const [config, setConfig] = useState<AppConfig>(initialConfig);
   const [appState, setAppState] = useState<AppState>(initialState);
+  const [appVersion, setAppVersion] = useState<string>('');
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -150,6 +152,11 @@ export const ConfigManager = forwardRef<ConfigManagerRef, ConfigManagerProps>(({
     };
     
     loadSavedCredentials();
+  }, []);
+
+  // アプリバージョン取得
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => setAppVersion('不明'));
   }, []);
 
   // バケット設定時に自動でライフサイクル状況をチェック + 健全性監視開始
@@ -1311,7 +1318,7 @@ export const ConfigManager = forwardRef<ConfigManagerRef, ConfigManagerProps>(({
           </div>
           
           <div className="app-info">
-            <div className="app-name">ReelVault</div>
+            <div className="app-name">ReelVault v{appVersion}</div>
             <div className="app-subtitle">映像制作者のためのアーカイブツール</div>
             <div className="app-copyright">© 2025 CIVICTECH.TV, LLC</div>
           </div>
@@ -1391,7 +1398,7 @@ export const ConfigManager = forwardRef<ConfigManagerRef, ConfigManagerProps>(({
                 <label>アプリバージョン:</label>
                 <input
                   type="text"
-                  value={config.version}
+                  value={appVersion || '読み込み中...'}
                   disabled
                   className="readonly-input"
                 />


### PR DESCRIPTION
## 概要
アプリケーションのバージョン情報を取得し、UI（フッター）とシステムトレイメニューに表示する機能を追加します。
これにより、ユーザーが現在使用しているアプリのバージョンを簡単に確認できるようになります。

## 主な変更点
- **バージョン取得ロジック**: `tauri.conf.json`の`package.version`からバージョンを取得するよう変更しました。
- **UI表示**:
  - `ConfigManager.tsx`のフッターに「ReelVault vX.Y.Z」の形式でバージョンを表示します。
  - アプリ起動時にバージョン情報を取得し、ステートで管理します。
- **トレイメニュー**:
  - システムトレイに「ReelVaultのバージョン情報」メニュー項目を追加しました。
  - 選択すると、バージョン情報が記載されたダイアログが表示されます。
- **Rustバックエンド**:
  - `tauri-plugin-dialog`を使用して、ネイティブのメッセージダイアログを表示するよう修正しました。
  - APIの呼び出し方がTauri v2のビルダーパターンに沿うよう、`.blocking_show()`を使用する形に修正しました。
- **テスト**:
  - `ConfigManager.test.tsx`にて、バージョン情報が正しく表示されることを確認するテストケースを追加・更新しました。
  - `getVersion`のモックを適切に設定しました。

## 関連Issue
- Close #105 

## スクリーンショット
**バージョンダイアログ**
![image](https://user-images.githubusercontent.com/1026930/288198229-b8352528-d890-4e3a-b850-8b0ab0196238.png)

**フッター表示**
![image](https://user-images.githubusercontent.com/1026930/288198255-fd9b68a5-c54d-4503-a12b-3e5e43c8ed45.png)

## 動作確認
1. アプリを起動する
2. 画面左下のフッターに`ReelVault v0.1.0`と表示されていることを確認する
3. システムトレイのアイコンをクリックし、「ReelVaultのバージョン情報」を選択する
4. バージョン情報が記載されたダイアログが表示されることを確認する
